### PR TITLE
Recipe attribute should pull from `node`, not `node.default`

### DIFF
--- a/recipes/function_keys.rb
+++ b/recipes/function_keys.rb
@@ -1,11 +1,11 @@
-as_fn_keys = node.default['function_keys']['use_function_keys_as_function_keys'] ? "0" : "1"
+as_fn_keys = node['function_keys']['use_function_keys_as_function_keys'] ? "0" : "1"
 
 # The following won't take effect until the person logs out & logs back in again.
 # THE BELT
-osx_defaults "Turn #{as_fn_keys ? "on" : "off" } function-keys-work-as-function keys" do
+osx_defaults "Turn #{as_fn_keys == "0" ? "on" : "off" } function-keys-work-as-function keys" do
   domain '.GlobalPreferences'
   key 'com.apple.keyboard.fnState'
-  boolean node.default['function_keys']['use_function_keys_as_function_keys']
+  boolean node['function_keys']['use_function_keys_as_function_keys']
 end
 
 # Attempt an interactive change.  Two req'ts: 1) user must be logged in 2) assistive devices enabled


### PR DESCRIPTION
`node.default` was preventing the override of `use_function_keys_as_function_keys` attribute