### PR TITLE
Fully specify GlobalPreferences domain location for function keys

### DIFF
--- a/recipes/function_keys.rb
+++ b/recipes/function_keys.rb
@@ -3,7 +3,7 @@ as_fn_keys = node.default['function_keys']['use_function_keys_as_function_keys']
 # The following won't take effect until the person logs out & logs back in again.
 # THE BELT
 osx_defaults "Turn #{as_fn_keys ? "on" : "off" } function-keys-work-as-function keys" do
-  domain '.GlobalPreferences'
+  domain "/Users/#{node['sprout']['user']}/Library/Preferences/.GlobalPreferences"
   key 'com.apple.keyboard.fnState'
   boolean node.default['function_keys']['use_function_keys_as_function_keys']
 end


### PR DESCRIPTION
This fixes the following error, encountered when sprouting a non-booted machine:

```
* execute[Turn on function-keys-work-as-function keys - .GlobalPreferences - com.apple.keyboard.fnState] action run[2015-08-20T10:56:55-07:00] INFO: Processing execute[Turn on function-keys-work-as-function keys - .GlobalPreferences - com.apple.keyboard.fnState] action run (/Users/minifast/sprout-wrap/cookbooks/osx/providers/defaults.rb line 4)

================================================================================
Error executing action `run` on resource 'execute[Turn on function-keys-work-as-function keys - .GlobalPreferences - com.apple.keyboard.fnState]'
================================================================================


Mixlib::ShellOut::ShellCommandFailed
------------------------------------
Expected process to exit with [0], but received '1'
---- Begin output of defaults write .GlobalPreferences com.apple.keyboard.fnState -boolean true ----
STDOUT:
STDERR: 2015-08-20 10:56:55.935 defaults[56689:126780] Could not write domain .GlobalPreferences; exiting
---- End output of defaults write .GlobalPreferences com.apple.keyboard.fnState -boolean true ----
Ran defaults write .GlobalPreferences com.apple.keyboard.fnState -boolean true returned 1
```

This mirrors other `osx_defaults` resource definitions, such as natural scrolling: https://github.com/pivotal-sprout/sprout-osx-settings/blob/fa7f68da19bbb9cc45da22020d9043fcfc7ee73e/recipes/osx_disable_natural_scrolling.rb#L2