### PR TITLE
add disable gatekeeper recipe

### DIFF
--- a/recipes/disable_gatekeeper.rb
+++ b/recipes/disable_gatekeeper.rb
@@ -1,0 +1,3 @@
+execute "disable gatekeeper"   do
+  command "spctl --master-disable"
+end


### PR DESCRIPTION
Gatekeeper is the setting behind the "allow apps downloaded from:" dialog in the security and privacy settings. This sets the radio button to "anywhere"